### PR TITLE
Fix syntax highlighting bug

### DIFF
--- a/treesitter-ros/grammar.js
+++ b/treesitter-ros/grammar.js
@@ -40,7 +40,7 @@ module.exports = grammar({
     const_definition: $ => seq($.const_name, '=', $.const_value),
     const_name: $ => /[A-Z_]+/,
     // TODO: const_value actual regex
-    const_value: $ => /[a-zA-Z0-9\.]+/,
-    identifier: $ => /[a-zA-Z0-9/_]+/,
+    const_value: $ => /[\"]?[a-zA-Z0-9\.]+[\"]?/,
+    identifier: $ => /[a-zA-Z0-9\./_]+/,
   }
 });

--- a/treesitter-ros/src/grammar.json
+++ b/treesitter-ros/src/grammar.json
@@ -203,11 +203,11 @@
     },
     "const_value": {
       "type": "PATTERN",
-      "value": "[a-zA-Z0-9\\.]+"
+      "value": "[\\\"]?[a-zA-Z0-9\\.]+[\\\"]?"
     },
     "identifier": {
       "type": "PATTERN",
-      "value": "[a-zA-Z0-9/_]+"
+      "value": "[a-zA-Z0-9\\./_]+"
     }
   },
   "extras": [

--- a/treesitter-ros/src/parser.c
+++ b/treesitter-ros/src/parser.c
@@ -300,535 +300,546 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(6);
-      if (lookahead == '#') ADVANCE(7);
-      if (lookahead == '-') ADVANCE(2);
-      if (lookahead == '=') ADVANCE(27);
-      if (lookahead == '[') ADVANCE(25);
-      if (lookahead == ']') ADVANCE(26);
-      if (lookahead == 'b') ADVANCE(56);
-      if (lookahead == 'd') ADVANCE(67);
-      if (lookahead == 'f') ADVANCE(50);
-      if (lookahead == 'i') ADVANCE(54);
-      if (lookahead == 's') ADVANCE(64);
-      if (lookahead == 't') ADVANCE(45);
-      if (lookahead == 'u') ADVANCE(48);
+      if (eof) ADVANCE(7);
+      if (lookahead == '#') ADVANCE(8);
+      if (lookahead == '-') ADVANCE(3);
+      if (lookahead == '=') ADVANCE(28);
+      if (lookahead == '[') ADVANCE(26);
+      if (lookahead == ']') ADVANCE(27);
+      if (lookahead == 'b') ADVANCE(58);
+      if (lookahead == 'd') ADVANCE(69);
+      if (lookahead == 'f') ADVANCE(52);
+      if (lookahead == 'i') ADVANCE(56);
+      if (lookahead == 's') ADVANCE(66);
+      if (lookahead == 't') ADVANCE(47);
+      if (lookahead == 'u') ADVANCE(50);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(0)
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(28);
-      if (('/' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          lookahead == '_') ADVANCE(29);
+      if (('.' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 1:
-      if (lookahead == '-') ADVANCE(10);
-      END_STATE();
-    case 2:
-      if (lookahead == '-') ADVANCE(1);
-      END_STATE();
-    case 3:
-      if (lookahead == '[') ADVANCE(25);
+      if (lookahead == '"') ADVANCE(5);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(3)
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(28);
-      if (('/' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          lookahead == ' ') SKIP(1)
+      if (lookahead == '.' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(31);
+      END_STATE();
+    case 2:
+      if (lookahead == '-') ADVANCE(11);
+      END_STATE();
+    case 3:
+      if (lookahead == '-') ADVANCE(2);
       END_STATE();
     case 4:
+      if (lookahead == '[') ADVANCE(26);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
           lookahead == ' ') SKIP(4)
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(29);
+      if (('.' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
+      END_STATE();
+    case 5:
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(29);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(31);
       END_STATE();
-    case 5:
-      if (eof) ADVANCE(6);
-      if (lookahead == '#') ADVANCE(7);
-      if (lookahead == '-') ADVANCE(2);
-      if (lookahead == 'b') ADVANCE(56);
-      if (lookahead == 'd') ADVANCE(67);
-      if (lookahead == 'f') ADVANCE(50);
-      if (lookahead == 'i') ADVANCE(54);
-      if (lookahead == 's') ADVANCE(64);
-      if (lookahead == 't') ADVANCE(45);
-      if (lookahead == 'u') ADVANCE(48);
+    case 6:
+      if (eof) ADVANCE(7);
+      if (lookahead == '#') ADVANCE(8);
+      if (lookahead == '-') ADVANCE(3);
+      if (lookahead == 'b') ADVANCE(58);
+      if (lookahead == 'd') ADVANCE(69);
+      if (lookahead == 'f') ADVANCE(52);
+      if (lookahead == 'i') ADVANCE(56);
+      if (lookahead == 's') ADVANCE(66);
+      if (lookahead == 't') ADVANCE(47);
+      if (lookahead == 'u') ADVANCE(50);
       if (lookahead == '\t' ||
           lookahead == '\n' ||
           lookahead == '\r' ||
-          lookahead == ' ') SKIP(5)
-      if (('/' <= lookahead && lookahead <= '9') ||
+          lookahead == ' ') SKIP(6)
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
-      END_STATE();
-    case 6:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 7:
-      ACCEPT_TOKEN(sym_comment_char);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 8:
-      ACCEPT_TOKEN(sym_comment_string);
-      if (lookahead == '\t' ||
-          lookahead == '\r' ||
-          lookahead == ' ') ADVANCE(8);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(9);
+      ACCEPT_TOKEN(sym_comment_char);
       END_STATE();
     case 9:
       ACCEPT_TOKEN(sym_comment_string);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(9);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(9);
+          lookahead != '\n') ADVANCE(10);
       END_STATE();
     case 10:
-      ACCEPT_TOKEN(sym_separator);
+      ACCEPT_TOKEN(sym_comment_string);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(10);
       END_STATE();
     case 11:
-      ACCEPT_TOKEN(anon_sym_bool);
-      if (('/' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+      ACCEPT_TOKEN(sym_separator);
       END_STATE();
     case 12:
-      ACCEPT_TOKEN(anon_sym_int8);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_bool);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 13:
-      ACCEPT_TOKEN(anon_sym_uint8);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_int8);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 14:
-      ACCEPT_TOKEN(anon_sym_int16);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_uint8);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 15:
-      ACCEPT_TOKEN(anon_sym_uint16);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_int16);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 16:
-      ACCEPT_TOKEN(anon_sym_int32);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_uint16);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 17:
-      ACCEPT_TOKEN(anon_sym_uint32);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_int32);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 18:
-      ACCEPT_TOKEN(anon_sym_int64);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_uint32);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 19:
-      ACCEPT_TOKEN(anon_sym_uint64);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_int64);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 20:
-      ACCEPT_TOKEN(anon_sym_float32);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_uint64);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 21:
-      ACCEPT_TOKEN(anon_sym_float64);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_float32);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 22:
-      ACCEPT_TOKEN(anon_sym_string);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_float64);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 23:
-      ACCEPT_TOKEN(anon_sym_time);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_string);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 24:
-      ACCEPT_TOKEN(anon_sym_duration);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(anon_sym_time);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(anon_sym_duration);
+      if (('.' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 28:
-      ACCEPT_TOKEN(sym_const_name);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_') ADVANCE(28);
-      if (('/' <= lookahead && lookahead <= '9') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 29:
+      ACCEPT_TOKEN(sym_const_name);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_') ADVANCE(29);
+      if (('.' <= lookahead && lookahead <= '9') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
+      END_STATE();
+    case 30:
       ACCEPT_TOKEN(sym_const_value);
+      END_STATE();
+    case 31:
+      ACCEPT_TOKEN(sym_const_value);
+      if (lookahead == '"') ADVANCE(30);
       if (lookahead == '.' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(29);
-      END_STATE();
-    case 30:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '1') ADVANCE(39);
-      if (lookahead == '3') ADVANCE(32);
-      if (lookahead == '6') ADVANCE(36);
-      if (lookahead == '8') ADVANCE(12);
-      if (('/' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
-      END_STATE();
-    case 31:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '1') ADVANCE(40);
-      if (lookahead == '3') ADVANCE(33);
-      if (lookahead == '6') ADVANCE(37);
-      if (lookahead == '8') ADVANCE(13);
-      if (('/' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(31);
       END_STATE();
     case 32:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(16);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '1') ADVANCE(41);
+      if (lookahead == '3') ADVANCE(34);
+      if (lookahead == '6') ADVANCE(38);
+      if (lookahead == '8') ADVANCE(13);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 33:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(17);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '1') ADVANCE(42);
+      if (lookahead == '3') ADVANCE(35);
+      if (lookahead == '6') ADVANCE(39);
+      if (lookahead == '8') ADVANCE(14);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '2') ADVANCE(20);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '2') ADVANCE(17);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 35:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '3') ADVANCE(34);
-      if (lookahead == '6') ADVANCE(38);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '2') ADVANCE(18);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 36:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(18);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '2') ADVANCE(21);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(19);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '3') ADVANCE(36);
+      if (lookahead == '6') ADVANCE(40);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '4') ADVANCE(21);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '4') ADVANCE(19);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(14);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '4') ADVANCE(20);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 40:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '6') ADVANCE(15);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '4') ADVANCE(22);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 41:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(66);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '6') ADVANCE(15);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 42:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'a') ADVANCE(63);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == '6') ADVANCE(16);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 43:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(23);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'a') ADVANCE(68);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 44:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'g') ADVANCE(22);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'a') ADVANCE(65);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 45:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(51);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'e') ADVANCE(24);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 46:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(52);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'g') ADVANCE(23);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 47:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(58);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'i') ADVANCE(53);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 48:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(55);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'i') ADVANCE(54);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 49:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(11);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'i') ADVANCE(60);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 50:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(59);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'i') ADVANCE(57);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 51:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'm') ADVANCE(43);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'l') ADVANCE(12);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 52:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(44);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'l') ADVANCE(61);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 53:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(24);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'm') ADVANCE(45);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 54:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(62);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'n') ADVANCE(46);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 55:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(65);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'n') ADVANCE(25);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 56:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(57);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'n') ADVANCE(64);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 57:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(49);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'n') ADVANCE(67);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 58:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(53);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'o') ADVANCE(59);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 59:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(42);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'o') ADVANCE(51);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 60:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(41);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'o') ADVANCE(55);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 61:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(46);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'o') ADVANCE(44);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 62:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(30);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'r') ADVANCE(43);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 63:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(35);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 'r') ADVANCE(48);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 64:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(61);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 't') ADVANCE(32);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 65:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(31);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 't') ADVANCE(37);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 66:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 't') ADVANCE(47);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 't') ADVANCE(63);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 67:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'u') ADVANCE(60);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 't') ADVANCE(33);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     case 68:
       ACCEPT_TOKEN(sym_identifier);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (lookahead == 't') ADVANCE(49);
+      if (('.' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(68);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
+      END_STATE();
+    case 69:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'u') ADVANCE(62);
+      if (('.' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
+      END_STATE();
+    case 70:
+      ACCEPT_TOKEN(sym_identifier);
+      if (('.' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(70);
       END_STATE();
     default:
       return false;
@@ -837,24 +848,24 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
 
 static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 5},
-  [2] = {.lex_state = 5},
-  [3] = {.lex_state = 5},
-  [4] = {.lex_state = 5},
-  [5] = {.lex_state = 5},
-  [6] = {.lex_state = 5},
-  [7] = {.lex_state = 5},
-  [8] = {.lex_state = 3},
-  [9] = {.lex_state = 3},
-  [10] = {.lex_state = 3},
-  [11] = {.lex_state = 3},
-  [12] = {.lex_state = 3},
-  [13] = {.lex_state = 3},
-  [14] = {.lex_state = 8},
+  [1] = {.lex_state = 6},
+  [2] = {.lex_state = 6},
+  [3] = {.lex_state = 6},
+  [4] = {.lex_state = 6},
+  [5] = {.lex_state = 6},
+  [6] = {.lex_state = 6},
+  [7] = {.lex_state = 6},
+  [8] = {.lex_state = 4},
+  [9] = {.lex_state = 4},
+  [10] = {.lex_state = 4},
+  [11] = {.lex_state = 4},
+  [12] = {.lex_state = 4},
+  [13] = {.lex_state = 4},
+  [14] = {.lex_state = 9},
   [15] = {.lex_state = 0},
   [16] = {.lex_state = 0},
   [17] = {.lex_state = 0},
-  [18] = {.lex_state = 4},
+  [18] = {.lex_state = 1},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {


### PR DESCRIPTION
Fixes #6 
Before, something like
```
string STR="foo"
a_b_c/d[] e
```
would get highlighted incorrectly.
Also floating point numbers now work properly